### PR TITLE
Minor additions

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -16,3 +16,4 @@ build_flags = -DENABLE_HOME_ASSISTANT
 lib_deps = 
 	adafruit/Adafruit NeoPixel@^1.12.4
 	bblanchon/ArduinoJson@^7.3.0
+monitor_speed = 115200

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,6 +27,7 @@
 #include <Adafruit_NeoPixel.h>
 #include <ArduinoJson.h>
 #include <SPIFFS.h>
+#include <ESPmDNS.h>
 
 // Internal Project Headers
 #include "BoardGenerator.h"
@@ -736,6 +737,15 @@ void setup()
   initHomeAssistant(HA_IP, HA_PORT, HA_ACCESS_TOKEN, "/api/services/script/turn_on");
   Serial.println("Home Assistant integration enabled");
 #endif
+  
+   // Initialize mDNS
+  if (!MDNS.begin("smartcatan")) {   // Set the hostname to "smartcatan.local"
+    Serial.println("Error setting up MDNS responder!");
+    while(1) {
+      delay(1000);
+    }
+  }
+  Serial.println("mDNS responder started");
 
   // Start the web server
   server.begin();


### PR DESCRIPTION
Adding the baud rate to platformio.ini will make it so everyone's boards are auto configured.

mDNS makes it so you can enter smartcatan.local and connect instead of looking up the IP address. May come in use if you end up making the ESP act as a router/hotspot instead of relying on a different wifi, or if you are visiting friends/store while playing.